### PR TITLE
Подправить отображение элементов

### DIFF
--- a/src/components/FormConstructor/FormConstructorFormBlockConfigure/Panels/ComponentsStructure/ComponentItems/styles.module.css
+++ b/src/components/FormConstructor/FormConstructorFormBlockConfigure/Panels/ComponentsStructure/ComponentItems/styles.module.css
@@ -7,7 +7,7 @@
   grid-template-columns: 1fr 1fr 1fr;
   overflow-y: auto;
   padding: var(--space-xs);
-  gap: var(--space-s);
+  gap: var(--space-xs);
 }
 
 @media screen and (max-width: 1900px) {

--- a/src/components/FormConstructor/FormConstructorFormBlockConfigure/Panels/Settings/BaseSettings/styles.module.css
+++ b/src/components/FormConstructor/FormConstructorFormBlockConfigure/Panels/Settings/BaseSettings/styles.module.css
@@ -1,8 +1,6 @@
 .marginAndPadding {
   display: flex;
   flex-direction: row;
-  padding-left: var(--space-s);
-  padding-right: var(--space-s);
 }
 
 .arrowAndText {
@@ -12,7 +10,5 @@
 }
 
 .textDecoration {
-  padding-left: var(--space-s);
-  padding-right: var(--space-s);
   padding-top: var(--space-s);
 }

--- a/src/components/FormConstructor/FormConstructorFormBlockConfigure/Panels/Settings/styles.module.css
+++ b/src/components/FormConstructor/FormConstructorFormBlockConfigure/Panels/Settings/styles.module.css
@@ -4,15 +4,14 @@
   flex-basis: 0;
   display: flex;
   flex-direction: column;
-
 }
 
 .settingsContainer {
   padding: 0.5rem;
-  min-width: 35rem;
-  max-width: 35rem;
+  min-width: 36rem;
+  max-width: 36rem;
 
-  border-left: 1px solid var(--color-typo-system)
+  border-left: 1px solid var(--color-typo-system);
 }
 
 .elementSettings {


### PR DESCRIPTION
1)Подправить отображение элементов
до) 
![image](https://github.com/Bright-Burn/ConstaConstructor/assets/113695658/660069e7-b5eb-419e-b2a7-607cbb5f5fa9)
после)
![image](https://github.com/Bright-Burn/ConstaConstructor/assets/113695658/294dec0c-d159-45f0-8710-0a8821c63098)
2)Подправить отображение базовых настроек
до)
![image](https://github.com/Bright-Burn/ConstaConstructor/assets/113695658/2ecb34e3-70c6-48d2-bf51-fed12b293762)
после)
![image](https://github.com/Bright-Burn/ConstaConstructor/assets/113695658/db199210-e91d-4977-81b4-63150c62300b)
